### PR TITLE
Update license in README to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ This is a little manual at the moment.
 2. Restart cloud9. The server-side plugin will detect the missing asset and rebuild it.
 
 ## License
-- Licensed under the GNU GENERAL PUBLIC LICENSE v3:
-  - http://www.gnu.org/licenses/gpl-3.0.en.html
+- Licensed under the MIT License:
+  - https://opensource.org/licenses/MIT
 
 ## Contributing
 


### PR DESCRIPTION
License was update to MIT as part of this CR https://github.com/jumbojett/c9.ide.theme.jett/pull/7 but it wasn't update on README file.

This change is just to update README to be consistent with current license